### PR TITLE
Add a 'multipart attribute' test

### DIFF
--- a/tests/correct/attr-multipart.ixml
+++ b/tests/correct/attr-multipart.ixml
@@ -1,0 +1,3 @@
+date: month, -',', -' '*, year . 
+@month: 'Feb', 'ruary' .
+year: ['0'-'9']+ .

--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -64,6 +64,23 @@
     </test-set>
 
 
+    <test-set name="attribute-multipart">
+      <description>
+        <p>Test that an attribute value constructed from multiple children
+        is correctly interpreted.</p>
+      </description>
+      <created by="ndw" on="2022-03-11"/>
+      <ixml-grammar-ref href="attr-multipart.ixml"/>
+      <test-case name="attribute-multipart">
+        <created by="ndw" on="2022-03-11"/>
+	<test-string>February, 2022</test-string>
+	<result>
+	  <assert-xml><date month="February" xmlns=""><year>2022</year></date></assert-xml>
+	</result>
+      </test-case>
+    </test-set>
+
+
     <test-set name="diary">
       <created by="SP" on="2021-12-16"/>
       <ixml-grammar-ref href="diary.ixml"/>


### PR DESCRIPTION
A new test:

```
date: month, -',', -' '*, year . 
@month: 'Feb', 'ruary' .
year: ['0'-'9']+ .
```

Tests that attributes composed from multiple literals are constructed properly.
