### PR TITLE
Fix the expected result of expr1

### DIFF
--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -176,6 +176,8 @@
 		  change="remove trailing whitespace from input"/>
 	<modified by="MSM" on="2022-01-01"
 		  change="remove whitespace from expected result"/>
+	<modified by="ndw" on="2022-03-21"
+		  change="changed to the correct error, not-a-sentence"/>
 	<test-string-ref href="expr1.inp"/>
 	<description>
 	  <p>We may need a new assertion: if taken literally this
@@ -187,10 +189,7 @@
 	  <p>To be discussed, probably at length.</p>
 	</description>
 	<result>
-	  <assert-not-a-grammar/>
-	  <!--
-          <assert-xml-ref href="expr1.output.xml"/>
-	  -->
+	  <assert-not-a-sentence/>
 	</result>
       </test-case>
     </test-set>


### PR DESCRIPTION
This is the test that will not rest.

I believe we've agreed that the result of this test should be an error. However, the test catalog currently asserts that it is "not a grammar". I don't think that's correct. This PR changes it to "not a sentence" which is better.

The description of the test suggests that we may need a new assertion. Perhaps that would be best. We could add, for example, `assert-not-xml`. If anyone thinks that's substantially better, just say so.

@cmsmcq I think you're the de facto maintainer of the test schemas, but if it's more convenient, I can make the change and send you a PR for the schemas.
