### PR TITLE
Updated to the 2022-04-15 grammar

### DIFF
--- a/samples/ABNF/ABNF.ixml
+++ b/samples/ABNF/ABNF.ixml
@@ -26,11 +26,11 @@ c-wsp         = WSP | (c-nl, WSP).
 
 c-nl          = comment | CRLF.  { comment or newline }
 
-comment       = ";", (WSP | VCHAR)* CRLF.
+comment       = ";", (WSP | VCHAR)*, CRLF.
 
-alternation   = concatenation * (c-wsp*, "/", c-wsp).
+alternation   = concatenation ** (c-wsp*, "/", c-wsp).
 
-concatenation = repetition * (c-wsp+).
+concatenation = repetition ** (c-wsp+).
 
 repetition    = repeat?, element.
 

--- a/samples/ABNF/README.md
+++ b/samples/ABNF/README.md
@@ -1,0 +1,8 @@
+# ABNF
+
+An ixml version of the grammar notation used in IETF Requests for
+Comment, as defined in [RFC 5234](https://www.rfc-editor.org/rfc/rfc5234.txt).
+
+## Change log
+
++ 2022-04-16, ndw, added README, corrected grammar to the 2022-04-15 editor’s draft.


### PR DESCRIPTION
1. Fixed a typo
2. Changed separators to the 2022-04-15 grammar syntax.
3. 