### PR TITLE
A namespaces draft

### DIFF
--- a/ixml-specification.html
+++ b/ixml-specification.html
@@ -63,6 +63,7 @@
   </li>
   <li><a href="#hints">Hints for Implementers</a></li>
   <li><a href="#ixml">IXML in IXML</a></li>
+  <li><a href="#errors">Errors</a></li>
   <li><a href="#references">References</a></li>
   <li><a href="#L3425">Informational References</a></li>
   <li><a href="#acknowledgments">Acknowledgements</a></li>
@@ -292,7 +293,8 @@ that it is in its own format, and therefore describes itself.</p>
 
 <p>A grammar is a sequence of one or more rules, surrounded and separated by
 spacing and comments. Spacing and comments are entirely optional, except that
-rules must be separated by at least one of either.</p>
+rules <span id="ref-s01" class="conform">must</span> be separated by at least one of either
+(<a class="error" href="#err-s01">error S01</a>).</p>
 <pre class="frag">ixml: s, rule++RS, s.</pre>
 
 <p>An <code>s</code> stands for an optional sequence of spacing and comments. A
@@ -379,16 +381,23 @@ match <code>a#a a!a a#a!a a!a#a a#a#a</code> etc.</p>
 <p>A nonterminal is an optionally marked name:</p>
 <pre class="frag">nonterminal: (mark, s)?, name, s.</pre>
 
-<p>This name refers to the rule that defines this name, which <span
-class="conform">must</span> exist, and there <span class="conform">must</span>
-only be one such rule.</p>
+<p>This name refers to the rule that defines this name, which
+<span id="ref-s02" class="conform">must</span> exist
+(<a class="error" href="#err-s02">error S02</a>),
+and there <span id="ref-s03" class="conform">must</span>
+only be one such rule
+(<a class="error" href="#err-s03">error S03</a>).</p>
 
 <h3 id="terminals">Terminals</h3>
 
 <p>A terminal is a literal or a set of characters. It matches characters in the
-input. A terminal <span class="conform">must not</span> be marked as an
-attribute (@), and a charset <span class="conform">must not</span> be marked as
-inserted (^). A terminal marked as deleted (-), serialises to the empty string.
+input. A terminal <span id="ref-s04" class="conform">must not</span> be marked as an
+attribute (@)
+(<a class="error" href="#err-s04">error S04</a>),
+and a charset <span id="ref-s05" class="conform">must not</span> be marked as
+inserted (^)
+(<a class="error" href="#err-s05">error S05</a>).
+A terminal marked as deleted (-), serialises to the empty string.
 A terminal marked as inserted (^) matches no characters on the input, but
 appears in the serialization.</p>
 <pre class="frag">-terminal: literal; 
@@ -405,7 +414,8 @@ matches only the exact same string in the input. Examples: <code>"yes"
 'yes'</code>. An inserted quoted string matches zero characters in the input
 (and succeeds).</p>
 
-<p>A string cannot extend over a line-break. The enclosing quote is represented
+<p id="ref-s11">A string cannot extend over a line-break
+(<a class="error" href="#err-s11">error S11</a>). The enclosing quote is represented
 in a string by doubling it; these two strings are identical: <code>'Isn''t it?'
 "Isn't it?"</code>, as are these: <code>"He said ""Don't!""" 'He said
 "Don''t!"'</code>.</p>
@@ -418,13 +428,19 @@ in a string by doubling it; these two strings are identical: <code>'Isn''t it?'
    schar: ~["'"; #a; #d];
           "'", -"'". {all characters except line breaks; quotes must be doubled}</pre>
 
-<p>An encoded character is an optionally marked hexadecimal number. It starts
+<p id="ref-s06">An encoded character is an optionally marked hexadecimal number. It starts
 with a hash symbol, followed by any number of hexadecimal digits, for example
-<code>#a0</code>. The digits are interpreted as a number in hexadecimal, and
+<code>#a0</code>. The digits are interpreted as a number in hexadecimal
+(<a class="error" href="#err-s06">error S06</a>)
+, and
 the character at that Unicode code-point is used [<a
-href="#unicode">Unicode</a>]. The number <span class="conform">must</span> be
-within the Unicode code-point range, and <span class="conform">must not</span>
-denote a Noncharacter or Surrogate code point.</p>
+href="#unicode">Unicode</a>].
+The number <span id="ref-s07" class="conform">must</span> be
+within the Unicode code-point range
+(<a class="error" href="#err-s07">error S07</a>), and
+<span id="ref-s08" class="conform">must not</span>
+denote a Noncharacter or Surrogate code point
+(<a class="error" href="#err-s08">error S08</a>).</p>
 
 <p>An unmarked or deleted encoded character matches that one character in the
 input. If marked as inserted, it matches no characters (but succeeds).</p>
@@ -463,8 +479,9 @@ exclusion: (tmark, s)?, -"~", s, set.
 
 <p>A range matches any character in the range from the start character to the
 end, inclusive, using the Unicode ordering. The <code>from</code> character
-<span class="conform">must not</span> be later in the ordering than the
-<code>to</code> character.</p>
+<span id="ref-s09" class="conform">must not</span> be later in the ordering than the
+<code>to</code> character
+(<a class="error" href="#err-s09">error S09</a>).</p>
 <pre class="frag">-range: from, s, -"-", s, to.
 @from: character.
   @to: character.</pre>
@@ -476,7 +493,8 @@ end, inclusive, using the Unicode ordering. The <code>from</code> character
 
 <p>A class is one or two letters, representing any character from the Unicode
 character category [<a href="#categories">Categories</a>] of that name, which
-<span class="conform">must</span> exist. E.g. <code>[Ll]</code> matches any
+<span id="ref-s10" class="conform">must</span> exist
+(<a class="error" href="#err-s10">error S10</a>). E.g. <code>[Ll]</code> matches any
 lower-case letter, <code>[Ll; Lu]</code> matches any upper- or lower-case
 character.</p>
 <pre class="frag">   -class: code.
@@ -610,17 +628,32 @@ nonterminal.</p>
   <li><strong>Deleted</strong>: the node is not serialised.</li>
 </ul>
 
-<p>Grammars <span class="conform">must</span> be written so that any
-serialization of a parse tree produced from the grammar is well-formed XML.</p>
+<p>Grammars <span id="ref-d01" class="conform">must</span> be written so that any
+serialization of a parse tree produced from the grammar is well-formed XML
+(<a class="error" href="#err-d01">error D01</a>).</p>
 
 <p>Note: This requirement means for instance that names of serialized elements
-and attributes must match the XML requirements; an element must not contain
-more than one attribute of a given name; invalid characters must not be
-serialized; a nonterminal being serialized as root element must not be marked
-as an attribute; in order to match the XML requirement of a single-rooted
-document, if the root rule is marked as hidden, all of its productions must
+and attributes must match the XML requirements; an element
+<span id="ref-d02" class="conform">must not</span> contain
+more than one attribute of a given name
+(<a class="error" href="#err-d02">error D02</a>);
+the names of all elements and attributes
+<span id="ref-d03" class="conform">must</span> conform to the requirements
+for XML names;
+invalid characters
+<span id="ref-d04" class="conform">must not</span> be
+serialized
+(<a class="error" href="#err-d04">error D04</a>);
+a nonterminal being serialized as root element
+<span id="ref-d05" class="conform">must not</span> be marked
+as an attribute
+(<a class="error" href="#err-d05">error D05</a>);
+in order to match the XML requirement of a single-rooted
+document, if the root rule is marked as hidden, all of its productions
+<span id="ref-d06" class="conform">must</span>
 produce exactly one non-hidden non-attribute nonterminal and no non-hidden
-terminals before or after that nonterminal.</p>
+terminals before or after that nonterminal
+(<a class="error" href="#err-d06">error D06</a>).</p>
 
 <p>A (necessarily contrived) example grammar that illustrates serialization
 rules is:</p>
@@ -919,6 +952,63 @@ serialisation</a> is available:</p>
          &lt;literal tmark='-' string='.'/&gt;
       &lt;/alt&gt;
    &lt;/rule&gt;</pre>
+
+<h2 id="errors">Errors</h2>
+
+<p>This section summarizes errors identified in this specification. Static errors
+are errors that can be identified by inspecting the grammar.</p>
+
+<dl id="static-errors">
+  <dt id="err-s01"><a href="#ref-s01">S01</a></dt>
+  <dd>It is an error if two rules are not separated by at least one whitespace
+  character or comment.</dd>
+  <dt id="err-s02"><a href="#ref-s02">S02</a></dt>
+  <dd>It is an error to use a nonterminal name that is not defined by a rule in the grammar.</dd>
+  <dt id="err-s03"><a href="#ref-s03">S03</a></dt>
+  <dd>It is an error if the grammar contains more than one rule for a given nonterminal name.</dd>
+  <dt id="err-s04"><a href="#ref-s04">S04</a></dt>
+  <dd>It is an error to mark a terminal as an attribute.</dd>
+  <dt id="err-s05"><a href="#ref-s05">S05</a></dt>
+  <dd>It is an error to mark a character set as an insertion.</dd>
+  <dt id="err-s06"><a href="#ref-s06">S06</a></dt>
+  <dd>It is an error if a hex encoding uses any characters not allowed in hexidecimal.</dd>
+  <dt id="err-s07"><a href="#ref-s07">S07</a></dt>
+  <dd>It is an error if the hexidecimal value is not within the Unicode code-point range.</dd>
+  <dt id="err-s08"><a href="#ref-s08">S08</a></dt>
+  <dd>It is an error if an encoded character denotes a Unicode noncharacter or surrogate code point.</dd>
+  <dt id="err-s09"><a href="#ref-s09">S09</a></dt>
+  <dd>It is an error if the first character in a range has a code point value
+  greater than the second character in the range.</dd>
+  <dt id="err-s10"><a href="#ref-s10">S10</a></dt>
+  <dd>It is an error to use a Unicode character category that is not defined in the
+  Unicode specification.</dd>
+  <dt id="err-s11"><a href="#ref-s11">S11</a></dt>
+  <dd>It is an error if a string contains a line break.</dd>
+</dl>
+
+<p>Dynamic errors arise when a particular input is processed with a grammar.</p>
+
+<dl id="dynamic-errors">
+  <dt id="err-d01"><a href="#ref-d01">D01</a></dt>
+  <dd>It is an error if the parse tree produced by a grammar cannot be represented as
+  well-formed XML.</dd>
+  <dt id="err-d02"><a href="#ref-d02">D02</a></dt>
+  <dd>It is an error if two or more attributes with the same name would be serialized on
+  the same element.</dd>
+  <dt id="err-d03"><a href="#ref-d03">D03</a></dt>
+  <dd>It is an error if the name of any element or attribute is not a valid XML name.</dd>
+  <dt id="err-d04"><a href="#ref-d04">D04</a></dt>
+  <dd>It is an error to attempt to serialize as XML any characters that are not permitted
+  in XML.</dd>
+  <dt id="err-d05"><a href="#ref-d05">D05</a></dt>
+  <dd>It is an error to attempt to serialize an attribute as the root node of an XML document.</dd>
+  <dt id="err-d06"><a href="#ref-d06">D06</a></dt>
+  <dd>It is an error if the parse tree does not contain exactly one top-level element.</dd>
+</dl>
+
+<p>Note: if error codes are reported in a context where it makes sense for them
+to appear in a namespace, they <span class="conform">should</span>
+be in the Invisible XML namespace.</p>
 
 <h2 id="references">References</h2>
 

--- a/ixml-specification.html
+++ b/ixml-specification.html
@@ -291,11 +291,14 @@ in the serialised result, giving:</p>
 <p>Here we describe the format of the grammar used to describe documents. Note
 that it is in its own format, and therefore describes itself.</p>
 
-<p>A grammar is a sequence of one or more rules, surrounded and separated by
-spacing and comments. Spacing and comments are entirely optional, except that
-rules <span id="ref-s01" class="conform">must</span> be separated by at least one of either
-(<a class="error" href="#err-s01">error S01</a>).</p>
-<pre class="frag">ixml: s, rule++RS, s.</pre>
+<p>A grammar is an optional prolog containing a version declaration
+followed by a sequence of one or more rules, surrounded and separated
+by spacing and comments. Spacing and comments are entirely optional,
+except that rules <span id="ref-s01" class="conform">must</span> be
+separated by at least one of either (<a class="error"
+href="#err-s01">error S01</a>).
+</p>
+<pre class="frag">ixml: s, prolog?, rule++RS, s.</pre>
 
 <p>An <code>s</code> stands for an optional sequence of spacing and comments. A
 comment is enclosed in braces, and can included nested comments, to enable
@@ -308,6 +311,36 @@ commenting out parts of a grammar:</p>
         -cr: -#d.
     comment: -"{", (cchar; comment)*, -"}".
      -cchar: ~["{}"].</pre>
+
+<h3 id="prolog">Version declaration</h3>
+
+<p>A grammar may begin with a version declaration.</p>
+
+<pre class="frag">        prolog = version, s.
+       version = -"ixml", RS, -"version", RS, -string, s, -'.' .</pre>
+
+<p>A version declaration consists of the words <code>ixml</code>
+and <code>version</code> followed by a string and terminated with
+a full stop. For example</p>
+
+<pre>ixml version "1.0" .</pre>
+
+<p>If a version declaration is present in an Invisible XML grammar, it is
+a statement by the author that the grammar conforms to the syntax and
+semantics of the version of ixml indicated in the declaration.</p>
+
+<p>An implemenation will either recognize the version string or it
+will not. If it recognizes the version string, it should process the
+grammar using the syntax and semantics of the declared version. If a
+version declaration is not present, an implementation should behave as
+if the grammar was labeled “1.0”.</p>
+
+<p>If it does not recognize the version string, it may issue a
+warning, but it must attempt to process the grammar. If it finds a
+syntactically valid interpretation of the grammar, it should proceed
+using the semantics of the version of Invisible XML under which it
+found a valid interpretation, otherwise it must reject the grammar.
+</p>
 
 <h3 id="rules">Rules</h3>
 

--- a/ixml-specification.html
+++ b/ixml-specification.html
@@ -20,6 +20,8 @@
       span.todo {background: yellow} 
       img {float: right; width: 25%; margin-left: 1em; border: thin black solid}
       span.conform {font-weight: bold}
+      add, .add { background-color: #aaffaa; }
+      del, .del { background-color: #ffaaaa; text-decoration: line-through; }
   </style>
   <!--
         <style type="text/css" rel="alternate stylesheet" title="Fragments">
@@ -312,12 +314,18 @@ commenting out parts of a grammar:</p>
     comment: -"{", (cchar; comment)*, -"}".
      -cchar: ~["{}"].</pre>
 
-<h3 id="prolog">Version declaration</h3>
+<h3 id="prolog">Version <add>and namespace </add>declaration<add>s</add></h3>
 
-<p>A grammar may begin with a version declaration.</p>
+<p>A grammar may begin with a version declaration<add> and/or namespace declarations.
+Both are optional.</add></p>
 
-<pre class="frag">        prolog = version, s.
+<pre class="frag del">        prolog = version, s.
        version = -"ixml", RS, -"version", RS, -string, s, -'.' .</pre>
+
+<pre class="frag add">       prolog = ((version, s, namespace**RS) | namespace++RS) .
+      version = -"ixml", RS, -"version", RS, -string, s, -'.' .</pre>
+
+<h4 class="add" id="version">Version declaration</h4>
 
 <p>A version declaration consists of the words <code>ixml</code>
 and <code>version</code> followed by a string and terminated with
@@ -342,6 +350,30 @@ using the semantics of the version of Invisible XML under which it
 found a valid interpretation, otherwise it must reject the grammar.
 </p>
 
+<h4 id="xmlns" class="add">Namespace declarations</h4>
+
+<p class="add">Namespace declarations associate XML namespaces with nonterminals.
+There <span id="ref-s12" class="conform">must not</span> be more than one default namespace declaration
+(<a class="error" href="#err-s12">error S12</a>).
+Any number of prefixes may be declared, but there
+<span id="ref-s13" class="conform">must not</span> be more than one declaration for any given prefix
+(<a class="error" href="#err-s13">error S13</a>). The default namespace applies only to nonterminals
+marked (explicitly or implicitly) with “<code>^</code>”.
+</p>
+
+<pre class="frag add">    namespace = defaultns | prefixns.
+   -defaultns = -"default", RS, -"namespace", s, -"=", s, @uri, s, -'.' .
+   -prefixns  = -"namespace", RS, @prefix, s, -"=", s, @uri, s, -'.' .
+          uri = -string .</pre>
+
+<p class="add">In the XML serialization of an ixml grammar, all namespace declarations present
+<span id="ref-s14" class="conform">must</span> appear as XML namespace declarations on the
+<code>&lt;ixml&gt;</code> document element
+(<a class="error" href="#err-s14">error S14</a>).
+Implementations <span class="conform">should not</span> put
+namespace declarations on any other elements or declare any namespaces not declared in
+the grammar.</p>
+
 <h3 id="rules">Rules</h3>
 
 <p>A rule consists of an optional mark, a name, and one or more alternatives.
@@ -363,9 +395,22 @@ used, for instance, for letters and digits. This is close to, but not identical
 with the XML definition of a name; it is the grammar author's responsibility to
 ensure that all serialised names match the requirements for an XML name [<a
 href="#xml">XML</a>].</p>
-<pre class="frag">        @name: namestart, namefollower*.
+
+<pre class="frag del">        @name: namestart, namefollower*.
    -namestart: ["_"; L].
 -namefollower: namestart; ["-.·‿⁀"; Nd; Mn].</pre>
+
+<p class="add">If a name contains a prefix, the grammar
+<span id="ref-s15" class="conform">must</span> contain a corresponding
+<a href="#xmlns">namespace declaration</a>
+(<a class="error" href="#err-s15">error S15</a>).</p>
+
+<pre class="frag add">        @name = (prefix, ':')?, ncname.
+      -ncname = namestart, namefollower*.
+      -prefix = -ncname .
+   -namestart = ["_" | L].
+-namefollower = namestart | ["-.·‿⁀" | Nd | Mn].</pre>
+
 
 <p>Alternatives are separated by a semicolon or a vertical bar. The grammar
 here uses semicolons.</p>
@@ -1017,6 +1062,15 @@ are errors that can be identified by inspecting the grammar.</p>
   Unicode specification.</dd>
   <dt id="err-s11"><a href="#ref-s11">S11</a></dt>
   <dd>It is an error if a string contains a line break.</dd>
+  <dt class="add" id="err-s12"><a href="#ref-s12">S12</a></dt>
+  <dd class="add">It is an error if more than one default namespace declaration is present.</dd>
+  <dt class="add" id="err-s13"><a href="#ref-s13">S13</a></dt>
+  <dd class="add">It is an error if more than one namespace declaration is present for any given prefix.</dd>
+  <dt class="add" id="err-s14"><a href="#ref-s14">S14</a></dt>
+  <dd class="add">It is an error if the XML serialization of a grammar does not place XML namespace declarations
+  for all of the namespaces declared in the grammar on the <code>ixml</code> document element.</dd>
+  <dt class="add" id="err-s15"><a href="#ref-s15">S15</a></dt>
+  <dd class="add">It is an error if a prefix used in a nonterminal name does not have a namespace declaration.</dd>
 </dl>
 
 <p>Dynamic errors arise when a particular input is processed with a grammar.</p>

--- a/ixml.ixml
+++ b/ixml.ixml
@@ -1,5 +1,8 @@
-{version 2022-04-15}
-         ixml: s, rule++RS, s.
+{version 2022-05-02}
+         ixml: s, prolog?, rule++RS, s.
+
+        prolog = version, s.
+       version = -"ixml", RS, -"version", RS, -string, s, -'.' .
 
            -s: (whitespace; comment)*. {Optional spacing}
           -RS: (whitespace; comment)+. {Required spacing}


### PR DESCRIPTION
In an effort to demonstrate how little has to change in the Invisible XML Specification to support namespaces in a manner that's consistent with modern XML usage, here is a pull request that does so.

You can see it formatted here: https://ndw.github.io/ixml/namespaces.html

I have added change markup to the relevant sections.

Close #66 

(This PR is based on the previous PR for the version declaration which is, in turn, based on the previous PR for error codes. I'm not sure it'll be entirely practical to accept this PR simply by merging it, I'm making it mostly to demonstrate the scale of the effort required.)