### PR TITLE
Update tests/reference/ixml.* to grammar of 17 May 2022

### DIFF
--- a/tests/reference/ixml.ixml
+++ b/tests/reference/ixml.ixml
@@ -1,8 +1,8 @@
-{ From the 2022-01-25 draft specification }
+{version 2022-05-17}
+         ixml: s, rule++RS, s.
 
-         ixml: s, rule+s, s.
-
-           -s: (whitespace; comment)*.
+           -s: (whitespace; comment)*. {Optional spacing}
+          -RS: (whitespace; comment)+. {Required spacing}
   -whitespace: -[Zs]; tab; lf; cr.
          -tab: -#9.
           -lf: -#a.
@@ -12,8 +12,8 @@
 
          rule: (mark, s)?, name, s, -["=:"], s, -alts, -".".
         @mark: ["@^-"].
-         alts: alt+(-[";|"], s).
-          alt: term*(-",", s).
+         alts: alt++(-[";|"], s).
+          alt: term**(-",", s).
         -term: factor;
                option;
                repeat0;
@@ -21,47 +21,48 @@
       -factor: terminal;
                nonterminal;
                -"(", s, alts, -")", s.
-      repeat0: factor, -"*", s, sep?.
-      repeat1: factor, -"+", s, sep?.
+      repeat0: factor, (-"*", s; -"**", s, sep).
+      repeat1: factor, (-"+", s; -"++", s, sep).
        option: factor, -"?", s.
           sep: factor.
   nonterminal: (mark, s)?, name, s.
-
-    -terminal: literal; 
-               charset.
-      literal: quoted;
-               encoded.
-      -quoted: (tmark, s)?, string.
 
         @name: namestart, namefollower*.
    -namestart: ["_"; L].
 -namefollower: namestart; ["-.·‿⁀"; Nd; Mn].
 
-       @tmark: ["^-"].
-      @string: -'"', dchar+, -'"', s;
-               -"'", schar+, -"'", s.
-        dchar: ~['"'; #a; #d];
+    -terminal: literal; 
+               charset.
+      literal: quoted;
+               encoded.
+      -quoted: (tmark, s)?, string, s.
+
+       @tmark: ["^-+"].
+      @string: -'"', dchar+, -'"';
+               -"'", schar+, -"'".
+       -dchar: ~['"'; #a; #d];
                '"', -'"'. {all characters except line breaks; quotes must be doubled}
-        schar: ~["'"; #a; #d];
+       -schar: ~["'"; #a; #d];
                "'", -"'". {all characters except line breaks; quotes must be doubled}
-     -encoded: (tmark, s)?, -"#", @hex, s.
-          hex: ["0"-"9"; "a"-"f"; "A"-"F"]+.
+     -encoded: (tmark, s)?, -"#", hex, s.
+         @hex: ["0"-"9"; "a"-"f"; "A"-"F"]+.
 
      -charset: inclusion; 
                exclusion.
     inclusion: (tmark, s)?,          set.
     exclusion: (tmark, s)?, -"~", s, set.
-         -set: -"[", s,  member*(-[";|"], s), -"]", s.
-      -member: literal;
+         -set: -"[", s,  (member, s)**(-[";|"], s), -"]", s.
+       member: string;
+               -"#", hex;
                range;
                class.
-        range: from, s, -"-", s, to, s.
+       -range: from, s, -"-", s, to.
         @from: character.
           @to: character.
    -character: -'"', dchar, -'"';
                -"'", schar, -"'";
                "#", hex.
-        class: code, s.
+       -class: code.
         @code: capital, letter?.
      -capital: ["A"-"Z"].
       -letter: ["a"-"z"].

--- a/tests/reference/ixml.xml
+++ b/tests/reference/ixml.xml
@@ -1,12 +1,13 @@
 
 <ixml>
+   <comment>version 2022-05-17</comment>
    <rule name='ixml'>
       <alt>
          <nonterminal name='s'/>
          <repeat1>
             <nonterminal name='rule'/>
             <sep>
-               <nonterminal name='s'/>
+               <nonterminal name='RS'/>
             </sep>
          </repeat1>
          <nonterminal name='s'/>
@@ -26,10 +27,26 @@
          </repeat0>
       </alt>
    </rule>
+   <comment>Optional spacing</comment>
+   <rule mark='-' name='RS'>
+      <alt>
+         <repeat1>
+            <alts>
+               <alt>
+                  <nonterminal name='whitespace'/>
+               </alt>
+               <alt>
+                  <nonterminal name='comment'/>
+               </alt>
+            </alts>
+         </repeat1>
+      </alt>
+   </rule>
+   <comment>Required spacing</comment>
    <rule mark='-' name='whitespace'>
       <alt>
          <inclusion tmark='-'>
-            <class code='Zs'/>
+            <member code='Zs'/>
          </inclusion>
       </alt>
       <alt>
@@ -76,7 +93,7 @@
    <rule mark='-' name='cchar'>
       <alt>
          <exclusion>
-            <literal string='{}'/>
+            <member string='{}'/>
          </exclusion>
       </alt>
    </rule>
@@ -93,7 +110,7 @@
          <nonterminal name='name'/>
          <nonterminal name='s'/>
          <inclusion tmark='-'>
-            <literal string='=:'/>
+            <member string='=:'/>
          </inclusion>
          <nonterminal name='s'/>
          <nonterminal mark='-' name='alts'/>
@@ -103,7 +120,7 @@
    <rule mark='@' name='mark'>
       <alt>
          <inclusion>
-            <literal string='@^-'/>
+            <member string='@^-'/>
          </inclusion>
       </alt>
    </rule>
@@ -115,7 +132,7 @@
                <alts>
                   <alt>
                      <inclusion tmark='-'>
-                        <literal string=';|'/>
+                        <member string=';|'/>
                      </inclusion>
                      <nonterminal name='s'/>
                   </alt>
@@ -171,21 +188,33 @@
    <rule name='repeat0'>
       <alt>
          <nonterminal name='factor'/>
-         <literal tmark='-' string='*'/>
-         <nonterminal name='s'/>
-         <option>
-            <nonterminal name='sep'/>
-         </option>
+         <alts>
+            <alt>
+               <literal tmark='-' string='*'/>
+               <nonterminal name='s'/>
+            </alt>
+            <alt>
+               <literal tmark='-' string='**'/>
+               <nonterminal name='s'/>
+               <nonterminal name='sep'/>
+            </alt>
+         </alts>
       </alt>
    </rule>
    <rule name='repeat1'>
       <alt>
          <nonterminal name='factor'/>
-         <literal tmark='-' string='+'/>
-         <nonterminal name='s'/>
-         <option>
-            <nonterminal name='sep'/>
-         </option>
+         <alts>
+            <alt>
+               <literal tmark='-' string='+'/>
+               <nonterminal name='s'/>
+            </alt>
+            <alt>
+               <literal tmark='-' string='++'/>
+               <nonterminal name='s'/>
+               <nonterminal name='sep'/>
+            </alt>
+         </alts>
       </alt>
    </rule>
    <rule name='option'>
@@ -212,6 +241,34 @@
          </option>
          <nonterminal name='name'/>
          <nonterminal name='s'/>
+      </alt>
+   </rule>
+   <rule mark='@' name='name'>
+      <alt>
+         <nonterminal name='namestart'/>
+         <repeat0>
+            <nonterminal name='namefollower'/>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark='-' name='namestart'>
+      <alt>
+         <inclusion>
+            <member string='_'/>
+            <member code='L'/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule mark='-' name='namefollower'>
+      <alt>
+         <nonterminal name='namestart'/>
+      </alt>
+      <alt>
+         <inclusion>
+            <member string='-.·‿⁀'/>
+            <member code='Nd'/>
+            <member code='Mn'/>
+         </inclusion>
       </alt>
    </rule>
    <rule mark='-' name='terminal'>
@@ -241,40 +298,13 @@
             </alts>
          </option>
          <nonterminal name='string'/>
-      </alt>
-   </rule>
-   <rule mark='@' name='name'>
-      <alt>
-         <nonterminal name='namestart'/>
-         <repeat0>
-            <nonterminal name='namefollower'/>
-         </repeat0>
-      </alt>
-   </rule>
-   <rule mark='-' name='namestart'>
-      <alt>
-         <inclusion>
-            <literal string='_'/>
-            <class code='L'/>
-         </inclusion>
-      </alt>
-   </rule>
-   <rule mark='-' name='namefollower'>
-      <alt>
-         <nonterminal name='namestart'/>
-      </alt>
-      <alt>
-         <inclusion>
-            <literal string='-.·‿⁀'/>
-            <class code='Nd'/>
-            <class code='Mn'/>
-         </inclusion>
+         <nonterminal name='s'/>
       </alt>
    </rule>
    <rule mark='@' name='tmark'>
       <alt>
          <inclusion>
-            <literal string='^-'/>
+            <member string='^-+'/>
          </inclusion>
       </alt>
    </rule>
@@ -285,7 +315,6 @@
             <nonterminal name='dchar'/>
          </repeat1>
          <literal tmark='-' string='"'/>
-         <nonterminal name='s'/>
       </alt>
       <alt>
          <literal tmark='-' string='&apos;'/>
@@ -293,15 +322,14 @@
             <nonterminal name='schar'/>
          </repeat1>
          <literal tmark='-' string='&apos;'/>
-         <nonterminal name='s'/>
       </alt>
    </rule>
-   <rule name='dchar'>
+   <rule mark='-' name='dchar'>
       <alt>
          <exclusion>
-            <literal string='"'/>
-            <literal hex='a'/>
-            <literal hex='d'/>
+            <member string='"'/>
+            <member hex='a'/>
+            <member hex='d'/>
          </exclusion>
       </alt>
       <alt>
@@ -310,12 +338,12 @@
       </alt>
    </rule>
    <comment>all characters except line breaks; quotes must be doubled</comment>
-   <rule name='schar'>
+   <rule mark='-' name='schar'>
       <alt>
          <exclusion>
-            <literal string='&apos;'/>
-            <literal hex='a'/>
-            <literal hex='d'/>
+            <member string='&apos;'/>
+            <member hex='a'/>
+            <member hex='d'/>
          </exclusion>
       </alt>
       <alt>
@@ -335,17 +363,17 @@
             </alts>
          </option>
          <literal tmark='-' string='#'/>
-         <nonterminal mark='@' name='hex'/>
+         <nonterminal name='hex'/>
          <nonterminal name='s'/>
       </alt>
    </rule>
-   <rule name='hex'>
+   <rule mark='@' name='hex'>
       <alt>
          <repeat1>
             <inclusion>
-               <range from='0' to='9'/>
-               <range from='a' to='f'/>
-               <range from='A' to='F'/>
+               <member from='0' to='9'/>
+               <member from='a' to='f'/>
+               <member from='A' to='F'/>
             </inclusion>
          </repeat1>
       </alt>
@@ -391,12 +419,17 @@
          <literal tmark='-' string='['/>
          <nonterminal name='s'/>
          <repeat0>
-            <nonterminal name='member'/>
+            <alts>
+               <alt>
+                  <nonterminal name='member'/>
+                  <nonterminal name='s'/>
+               </alt>
+            </alts>
             <sep>
                <alts>
                   <alt>
                      <inclusion tmark='-'>
-                        <literal string=';|'/>
+                        <member string=';|'/>
                      </inclusion>
                      <nonterminal name='s'/>
                   </alt>
@@ -407,9 +440,13 @@
          <nonterminal name='s'/>
       </alt>
    </rule>
-   <rule mark='-' name='member'>
+   <rule name='member'>
       <alt>
-         <nonterminal name='literal'/>
+         <nonterminal name='string'/>
+      </alt>
+      <alt>
+         <literal tmark='-' string='#'/>
+         <nonterminal name='hex'/>
       </alt>
       <alt>
          <nonterminal name='range'/>
@@ -418,14 +455,13 @@
          <nonterminal name='class'/>
       </alt>
    </rule>
-   <rule name='range'>
+   <rule mark='-' name='range'>
       <alt>
          <nonterminal name='from'/>
          <nonterminal name='s'/>
          <literal tmark='-' string='-'/>
          <nonterminal name='s'/>
          <nonterminal name='to'/>
-         <nonterminal name='s'/>
       </alt>
    </rule>
    <rule mark='@' name='from'>
@@ -454,10 +490,9 @@
          <nonterminal name='hex'/>
       </alt>
    </rule>
-   <rule name='class'>
+   <rule mark='-' name='class'>
       <alt>
          <nonterminal name='code'/>
-         <nonterminal name='s'/>
       </alt>
    </rule>
    <rule mark='@' name='code'>
@@ -471,14 +506,14 @@
    <rule mark='-' name='capital'>
       <alt>
          <inclusion>
-            <range from='A' to='Z'/>
+            <member from='A' to='Z'/>
          </inclusion>
       </alt>
    </rule>
    <rule mark='-' name='letter'>
       <alt>
          <inclusion>
-            <range from='a' to='z'/>
+            <member from='a' to='z'/>
          </inclusion>
       </alt>
    </rule>


### PR DESCRIPTION
This pull request updates the ixml specification grammars in test/references to the versions of 17 May 2022.  (When we get new versions, I'll make another PR.  But I don't see value in waiting.)

As far as I know, these are referred to only in the two catalogs syntax/catalog-as-instance-tests-{ixml,xml}.xml

This should resolve issue #86 