### PR TITLE
Make correct/test-catalog.xml#expr1#expr1 expect a dynamic error

### DIFF
--- a/tests/correct/expr1.ixml
+++ b/tests/correct/expr1.ixml
@@ -1,7 +1,7 @@
 expression: expr.
--expr: term+plusop.
+-expr: term++plusop.
 @plusop: "+"; "-".
-term: -factor; factor, mulop, factor+mulop.
+term: -factor; factor, mulop, factor++mulop.
 @mulop: "*"; "/".
 factor: id; number; bracketed.
 bracketed: -"(", expr, -")".

--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -1,10 +1,11 @@
 <test-catalog xmlns="https://github.com/cmsmcq/ixml-tests"
-              release-date="2021-12-21"
+              release-date="2022-05-24"
 	      name="Amsterdam Test Suite 1, correct tests">
 
   <description>
-    <p>Tests provided by Steven Pemberton in December 2021,
-    with corrections of 21 December. Reorganized by Norm Tovey-Walsh, February 2022.</p>
+    <p>Tests provided by Steven Pemberton in December 2021, with
+    corrections of 21 December. Reorganized by Norm Tovey-Walsh,
+    February 2022.</p>
 
   </description>
 
@@ -169,28 +170,32 @@
       <created by="SP" on="2021-12-16"/>
       <ixml-grammar-ref href="expr1.ixml"/>
       <test-case name="expr1">
-	<created by="SP" on="2021-12-16"/>
-	<modified by="MSM" on="2021-12-23"
-		  change="Change result"/>
-	<modified by="MSM" on="2022-01-01"
-		  change="remove trailing whitespace from input"/>
-	<modified by="MSM" on="2022-01-01"
-		  change="remove whitespace from expected result"/>
-	<test-string-ref href="expr1.inp"/>
-	<description>
-	  <p>We may need a new assertion: if taken literally this
-	  grammar produces non-XML output (multiple occurrences of an
-	  attribute on the same element).
-	  </p>
-	  <p>For now I'll class it as a run-time error in the
-	  grammar.  But is it an error in the grammar?</p>
-	  <p>To be discussed, probably at length.</p>
-	</description>
-	<result>
-	  <assert-not-a-grammar/>
-	  <!--
-          <assert-xml-ref href="expr1.output.xml"/>
-	  -->
+        <created by="SP" on="2021-12-16"/>
+        <modified by="MSM" on="2021-12-23"
+                  change="Change result"/>
+        <modified by="MSM" on="2022-01-01"
+                  change="remove trailing whitespace from input"/>
+        <modified by="MSM" on="2022-01-01"
+                  change="remove whitespace from expected result"/>
+        <modified by="MSM" on="2022-05-21"
+                  change="change to assert-dynamic-error"/>
+        <test-string-ref href="expr1.inp"/>
+        <description>
+          <p>Illustrates the way to handle dynamic errors in a test:
+          use assert-dynamic-error.</p>
+          <p>It's not formally a grammar error, since this grammar
+          will work fine for some inputs and processors are not
+          required to reject the grammar.  So assert-not-a-grammar
+          is not the right thing.</p>
+          <p>It's not formally a failure to parse the input, since
+          this input string is perfectly grammatical against this
+          input grammar.  So assert-not-a-sentence is not the right
+          thing.</p>
+          <p>The error arises in serialization and only at run time.
+          So assert-dynamic-error.</p>
+        </description>
+        <result>
+          <assert-dynamic-error/>
 	</result>
       </test-case>
     </test-set>


### PR DESCRIPTION
This change makes test case expr1#expr1 expect a dynamic error,
resolving a long-standing uncertainty about whether it would be better
coded with assert-not-a-sentence or with
assert-not-a-grammar.  (Answer:  neither.  Use assert-dynamic-error.)

It also updates expr1.ixml to use the current ++ operator for
positive repetition with separator.

This change effectively answers the original question in issue #31 by using
the new kind of assertion added to the schema some time ago.