### PR TITLE
Make test names case-insensitively unique

### DIFF
--- a/tests/ambiguous/test-catalog.xml
+++ b/tests/ambiguous/test-catalog.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
               release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Ambiguous inputs">
+	      name="Ambiguous inputs">
 
   <description>
     <p>Tests provided by Steven Pemberton in December 2021, with

--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
               release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Tests producing parse trees">
+	      name="Tests producing parse trees">
 
   <description>
     <p>Tests provided by Steven Pemberton in December 2021, with

--- a/tests/error/test-catalog.xml
+++ b/tests/error/test-catalog.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Error tests">
+	      name="Error tests">
 
   <description>
     <p>Tests intended to demonstrate errors that processors are required

--- a/tests/grammar-misc/insertion-tests.xml
+++ b/tests/grammar-misc/insertion-tests.xml
@@ -2,7 +2,7 @@
 	      xmlns:ixml="http://invisiblexml.org/NS"
 	      xmlns:jwL="https://lists.w3.org/Archives/Public/public-ixml/2022May/0099.html"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Insertion tests"
+	      name="Insertion tests"
 	      >
 
   <description>

--- a/tests/grammar-misc/prolog-tests.xml
+++ b/tests/grammar-misc/prolog-tests.xml
@@ -48,7 +48,7 @@
 	<tc:assert-not-a-sentence ixml:state="version-mismatch"/>
       </tc:result>
     </tc:test-case>
-    <tc:test-case name="B">
+    <tc:test-case name="B1">
       <tc:test-string>B</tc:test-string>
       <tc:result><tc:assert-xml>
 	<P ixml:state="version-mismatch">B</P>
@@ -60,7 +60,7 @@
 	<P ixml:state="version-mismatch">D</P>
       </tc:assert-xml></tc:result>
     </tc:test-case>
-    <tc:test-case name="b">
+    <tc:test-case name="b2">
       <tc:test-string>b</tc:test-string>
       <tc:result>
 	<tc:assert-not-a-sentence ixml:state="version-mismatch"/>
@@ -106,7 +106,7 @@
       <tc:test-string/>
       <tc:result><tc:assert-not-a-sentence/></tc:result>
     </tc:test-case>
-    <tc:test-case name="B">
+    <tc:test-case name="B1">
       <tc:test-string>B</tc:test-string>
       <tc:result><tc:assert-xml>
 	<P>B</P>
@@ -118,7 +118,7 @@
 	<P>D</P>
       </tc:assert-xml></tc:result>
     </tc:test-case>
-    <tc:test-case name="b">
+    <tc:test-case name="b2">
       <tc:test-string>b</tc:test-string>
       <tc:result><tc:assert-not-a-sentence/></tc:result>
     </tc:test-case>
@@ -146,7 +146,7 @@
 	<tc:assert-not-a-grammar error-code="none"/>
       </tc:result>
     </tc:test-case>
-    <tc:test-case name="B">
+    <tc:test-case name="B1">
       <tc:test-string>B</tc:test-string>
       <tc:result><tc:assert-not-a-grammar error-code="none"/></tc:result>
     </tc:test-case>
@@ -185,7 +185,7 @@
       <tc:test-string/>
       <tc:result><tc:assert-not-a-sentence/></tc:result>
     </tc:test-case>
-    <tc:test-case name="B">
+    <tc:test-case name="B1">
       <tc:test-string>B</tc:test-string>
       <tc:result><tc:assert-xml>
 	<ixml>B</ixml>
@@ -197,7 +197,7 @@
 	<ixml>D</ixml>
       </tc:assert-xml></tc:result>
     </tc:test-case>
-    <tc:test-case name="b">
+    <tc:test-case name="b2">
       <tc:test-string>b</tc:test-string>
       <tc:result><tc:assert-not-a-sentence/></tc:result>
     </tc:test-case>

--- a/tests/grammar-misc/test-catalog.xml
+++ b/tests/grammar-misc/test-catalog.xml
@@ -2,7 +2,7 @@
 		 xmlns:ap="http://blackmesatech.com/2019/iXML/Aparecium"
                  xmlns:ixml="http://invisiblexml.org/NS"
 		 release-date="2022-06-01"
-		 name="iXML Community Group Test Suite - Improper grammars">
+		 name="Improper grammars">
   
   <tc:description>
     <tc:p>This test set collects some grammars which have

--- a/tests/ixml/test-catalog.xml
+++ b/tests/ixml/test-catalog.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
               release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - ixml tests">
+	      name="ixml tests">
 
   <description>
     <p>Tests provided by Steven Pemberton in December 2021,

--- a/tests/parse/test-catalog.xml
+++ b/tests/parse/test-catalog.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
               release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - parse tests">
+	      name="parse tests">
 
   <description>
     <p>Tests provided by Steven Pemberton in December 2021, with

--- a/tests/syntax/catalog-as-grammar-tests.xml
+++ b/tests/syntax/catalog-as-grammar-tests.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Syntax tests">
+	      name="Grammar Syntax tests">
 
   <description>
     <p>Syntax tests provided by Steven Pemberton in December 2021.</p>

--- a/tests/syntax/catalog-as-instance-tests-ixml.xml
+++ b/tests/syntax/catalog-as-instance-tests-ixml.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Syntax tests">
+	      name="Instance Syntax tests (ixml)">
 
   <description>
     <p>Syntax tests provided by Steven Pemberton in December 2021.</p>

--- a/tests/syntax/catalog-as-instance-tests-xml.xml
+++ b/tests/syntax/catalog-as-instance-tests-xml.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Syntax tests">
+	      name="Instance Syntax tests (xml)">
 
   <description>
     <p>Syntax tests provided by Steven Pemberton in December 2021.</p>

--- a/tests/syntax/catalog-of-correct-tests.xml
+++ b/tests/syntax/catalog-of-correct-tests.xml
@@ -1,6 +1,6 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
 	      release-date="2022-06-01"
-	      name="iXML Community Group Test Suite - Syntax tests">
+	      name="Correct Syntax tests">
 
   <description>
     <p>Syntax tests for grammar features. These tests all make assertions


### PR DESCRIPTION
It turns out that "unique" needs to be "case-insensitively unique" if you're going to use the names in filenames on a case-insensitive filesystem. Because I'd like to be able to do that, I'm renaming a few tests.