### PR TITLE
New nullable nonterminal tests

### DIFF
--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -1079,6 +1079,13 @@
 	<assert-xml><S xmlns=""><B/><B/>a</S></assert-xml>
       </result>
     </test-case>
+    <test-case name="leading-nullable-fail">
+      <created by="ndw" on="2022-06-19"/>
+      <test-string>aa</test-string>
+      <result>
+	<assert-not-a-sentence/>
+      </result>
+    </test-case>
   </test-set>
 
   <test-set name="leading-embedded-nullable">
@@ -1096,6 +1103,13 @@
       <test-string>a</test-string>
       <result>
 	<assert-xml><S xmlns=""><B><C/></B><B><C/></B>a</S></assert-xml>
+      </result>
+    </test-case>
+    <test-case name="leading-nullable-fail">
+      <created by="ndw" on="2022-06-19"/>
+      <test-string>aa</test-string>
+      <result>
+	<assert-not-a-sentence/>
       </result>
     </test-case>
   </test-set>

--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -1,5 +1,5 @@
 <test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
-              release-date="2022-06-01"
+              release-date="2022-06-17"
 	      name="Tests producing parse trees">
 
   <description>
@@ -1061,6 +1061,43 @@
 	<S xmlns=""><a>Keep 'calm'</a><b>;</b><c> </c><d>be 'happy'.</d></S>
       </assert-xml></result>
     </test-case> 
+  </test-set>
+
+  <test-set name="leading-nullable">
+    <description>
+      <p>Test that repeated nullable nonterminals are handled correctly.</p>
+    </description>
+    <created by="ndw" on="2022-06-17"/>
+    <ixml-grammar>
+      S = B, B, 'a'.
+      B = .
+    </ixml-grammar>
+    <test-case name="leading-nullable">
+      <created by="ndw" on="2022-06-17"/>
+      <test-string>a</test-string>
+      <result>
+	<assert-xml><S xmlns=""><B/><B/>a</S></assert-xml>
+      </result>
+    </test-case>
+  </test-set>
+
+  <test-set name="leading-embedded-nullable">
+    <description>
+      <p>Test that repeated nullable nonterminals are handled correctly.</p>
+    </description>
+    <created by="ndw" on="2022-06-17"/>
+    <ixml-grammar>
+      S = B, B, 'a'.
+      B = C .
+      C = .
+    </ixml-grammar>
+    <test-case name="leading-nullable">
+      <created by="ndw" on="2022-06-17"/>
+      <test-string>a</test-string>
+      <result>
+	<assert-xml><S xmlns=""><B><C/></B><B><C/></B>a</S></assert-xml>
+      </result>
+    </test-case>
   </test-set>
 
 </test-catalog>


### PR DESCRIPTION
I encountered these tests indirectly because of the way that I handle insertions. I think they represent a known wrinkle in constructing a parse forest from parser output. Both my Earley parser and my GLL parser fail the embedded nullable test at the moment.
