### PR TITLE
Allow a:b=c and a=b:c in the insert-separator-alternate test results

### DIFF
--- a/tests/grammar-misc/insertion-tests.xml
+++ b/tests/grammar-misc/insertion-tests.xml
@@ -196,6 +196,12 @@
         <assert-xml>
           <S xmlns="" ixml:state="ambiguous">a=b=c</S>
         </assert-xml>
+        <assert-xml>
+          <S xmlns="" ixml:state="ambiguous">a:b=c</S>
+        </assert-xml>
+        <assert-xml>
+          <S xmlns="" ixml:state="ambiguous">a=b:c</S>
+        </assert-xml>
       </result>
     </test-case>
   </test-set>


### PR DESCRIPTION
Close #116 
