### PR TITLE
Supply additional correct results for g27.c03 and g57.c05

### DIFF
--- a/tests/misc/misc-021-040-catalog.xml
+++ b/tests/misc/misc-021-040-catalog.xml
@@ -1,7 +1,7 @@
 <tc:test-catalog xmlns:tc="https://github.com/invisibleXML/ixml/test-catalog"
 		 xmlns:ixml="http://invisiblexml.org/NS"
 		 name="Misc tests 2"
-		 release-date="2022-06-13"
+		 release-date="2022-06-28"
 		 >
   <tc:description>
     <tc:p>Grammars 21-40.</tc:p>
@@ -1172,7 +1172,21 @@
 		></C></Z></D></C></B></F></E></D></C></Z></D
 	      ></C></Z></D></C></Z></D></C></Z></D></C></B
 	    ></Y></E></D></C></B></Y></E></D></C></B></A
-	  ></S>
+          ></S>
+	</tc:assert-xml>
+	<tc:assert-xml>
+          <S xmlns:ixml="http://invisiblexml.org/NS"
+              ixml:state="ambiguous"
+             ><A><B><C><D><Z><C><D><E><Y><B
+               ><C><D><Z><C><D><E><F><B><C><D
+                 ><Z><C><D><E><Y><B><C><D><Z><C
+                   ><D><E><F
+                     ><G
+                   /></F></E></D
+                 ></C></Z></D></C></B></Y></E></D></C></Z
+               ></D></C></B></F></E></D></C></Z></D></C
+             ></B></Y></E></D></C></Z></D></C></B></A
+          ></S>	  
 	</tc:assert-xml>
 	
 	<!--* and many many more *-->

--- a/tests/misc/misc-041-060-catalog.xml
+++ b/tests/misc/misc-041-060-catalog.xml
@@ -2,7 +2,7 @@
 		 xmlns:ixml="http://invisiblexml.org/NS"
 		 xmlns:ap="http://blackmesatech.com/2019/iXML/Aparecium"		 
 		 name="Misc tests 3"
-		 release-date="2022-06-21"
+		 release-date="2022-06-28"
 		 >
   <tc:description>
     <tc:p>Grammars 41-60.</tc:p>
@@ -4162,6 +4162,13 @@
              >a<B>b</B></S></B></B></S></B><B>b</B
              ></B><B>b</B></B
           ></S>
+	</tc:assert-xml>
+	<tc:assert-xml>
+	  <S ixml:state="ambiguous"
+	     >a<B>a<B>a<B>b<S>a<B>a<B>b</B><B>b</B
+	     ></B></S></B><B>a<B>b</B><B>b</B></B
+	     ></B><B>b</B></B
+	  ></S>
 	</tc:assert-xml>
       </tc:result>
     </tc:test-case>


### PR DESCRIPTION
This pull request supplies additional correct answers for a couple of test cases with infinite ambiguity.

The idea is and remains that processors which make deterministic choices in cases of ambiguity should add their results to the test catalogs so their results will be recognized as correct on later test runs.  