### PR TITLE
Fixed 1.0 link, added link to CG page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,12 @@ text as structured information.</p>
 <div class="specification">
 <h2>Specification</h2>
 
-<p><a href="ixml-specification.html">Invisible XML</a> (ixml) 1.0 was
+<p><a href="1.0/">Invisible XML</a> (ixml) 1.0 was
 published on 10 June, 2022. The grammar of Invisible XML is defined
 with Invisible XML. The ixml grammar for ixml is available in
 <a href="ixml.ixml">ixml format</a> or in <a href="ixml.xml">xml format</a>.
+Invisible XML was developed by the <a href="https://www.w3.org/community/ixml/">Invisible
+Markup Community Group</a> at the <a href="https://www.w3.org/">W3C</a>.
 </p>
 
 </div>


### PR DESCRIPTION
I thought we had fixed the homepage so that the link to the 1.0 specification went to the stable version in the 1.0 directory, but that was apparently not the case.

I also added a link to the W3C community page.
