### PR TITLE
New (correct) results for ambiguous grammars

### DIFF
--- a/tests/misc/misc-001-020-catalog.xml
+++ b/tests/misc/misc-001-020-catalog.xml
@@ -1121,6 +1121,7 @@ Number  = [0-9]+
             <S ixml:state="ambiguous"
                ><A/><B>x</B></S>
           </tc:assert-xml>
+	  <tc:assert-xml><S ixml:state="ambiguous"><B>x</B><C/></S></tc:assert-xml>
 	  <!-- ... etc. ... -->
 	</tc:result>
       </tc:test-case>
@@ -1345,6 +1346,11 @@ Number  = [0-9]+
           ><A>a</A></A><A>a</A></A><A>a</A></A><A>a</A
           ></A><A>a</A></S>
 	</tc:assert-xml>
+	<!-- ... -->
+	<tc:assert-xml>
+          <S ixml:state="ambiguous"><A><A>a</A><A>a</A></A
+          ><A>aaaaaa</A></S>
+        </tc:assert-xml>
 	<!-- ... -->
       </tc:result>
     </tc:test-case>

--- a/tests/misc/misc-021-040-catalog.xml
+++ b/tests/misc/misc-021-040-catalog.xml
@@ -525,6 +525,13 @@
 	      /><A/><B/><C/><D/><E/><F/><G
 	    /></S>
 	  </tc:assert-xml>
+	  <tc:assert-xml>
+            <!-- produced by NineML using the GLL parser. -->
+	    <S ixml:state="ambiguous"
+               ><A/><B/><C/><D/><C/><D/><E
+               /><F/><B/><C/><D/><E/><F/><G
+            /></S>
+	  </tc:assert-xml>
 	  <!-- ... and others ... -->
 	</tc:result>
       </tc:test-case>
@@ -771,6 +778,11 @@
             /><W/><A/><B/><C/><D/><E/><F/><G
             /></S>
 	</tc:assert-xml>
+	<tc:assert-xml>
+          <!-- produced by NineML using the GLL parser. -->
+          <S ixml:state="ambiguous"><A/><B/><C/><D/><E/><Y/><B
+          /><C/><D/><Z/><C/><D/><E/><F/><G/></S>
+        </tc:assert-xml>
 	<!-- and many more ... -->
       </tc:result>
     </tc:test-case>
@@ -1188,7 +1200,15 @@
              ></B></Y></E></D></C></Z></D></C></B></A
           ></S>	  
 	</tc:assert-xml>
-	
+
+	<tc:assert-xml>
+          <S ixml:state="ambiguous"
+             ><A><B><C><D><E><F><B><C><D><Z><C><D><E><Y><B
+             ><C><D><Z><C><D><E><F><G/></F></E></D></C></Z
+             ></D></C></B></Y></E></D></C></Z></D></C></B
+             ></F></E></D></C></B></A
+          ></S>
+        </tc:assert-xml>
 	<!--* and many many more *-->
       </tc:result>
     </tc:test-case>

--- a/tests/misc/misc-041-060-catalog.xml
+++ b/tests/misc/misc-041-060-catalog.xml
@@ -4273,6 +4273,14 @@
              >a</A></A></S></B><B>b</B></B></S></A
              ></S></B></S>
 	</tc:assert-xml>
+	<tc:assert-xml>
+	  <S ixml:state="ambiguous"
+             >a<B>b<S>b<A>a<S>a<B>a<B>b</B><B>b<S
+             >b<A>b<A>a</A><A>a<S>a<B>a<B>b</B><B
+             >b<S>b<A>a<S>a<B>b</B></S></A></S></B
+             ></B></S></A></A></S></B></B></S></A
+             ></S></B></S>
+        </tc:assert-xml>
       </tc:result>
     </tc:test-case>
   </tc:test-set>


### PR DESCRIPTION
This PR adds several new correct results for ambiguous grammars in the 'misc' tests.

These are the results that my GLL parser produces.