### PR TITLE
Edit-in-place to add errata to 1.0 specification

### DIFF
--- a/1.0/errata.html
+++ b/1.0/errata.html
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+ xmlns:owl="http://www.w3.org/2002/07/owl#"
+ xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+ xmlns:foaf="http://xmlns.com/foaf/0.1/"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <title>Invisible XML Specification Errata</title>
+  <style type="text/css">
+      body {margin-left: auto; margin-right:auto; max-width: 50em;}
+      h1, h2 {font-family: sans-serif; clear: both}
+      pre {margin-left: 2em; padding: 0.5em 0 0.5em 1em; background-color: #ddf}
+      code {color: #A00}
+      div {border: thin red solid; padding-left: 1em; padding-right: 1em;}
+      span.todo {background: yellow} 
+      img {float: right; width: 25%; margin-left: 1em; border: thin black solid}
+      span.conform {font-weight: bold}
+ </style>
+</head>
+<body>
+<h1>Invisible XML Specification Errata</h1>
+
+<p>Version: <!--$date=-->2022-09-29<!--$--></p>
+
+<h2 id="status">Status</h2>
+
+<p>This document lists errata on the
+<a href="index.html">Invisible XML 1.0 Specification</a>.</p>
+
+<h2 id="proposed">Proposed errata</h2>
+
+<h3>E001: The Unicode character class “LC”</h3>
+
+<p>The definition of the nonterminal <code>letter</code> is changed to
+<code>["A"-"Z" | "a"-"z"]</code> to address the fact that recent versions of Unicode
+include the class “LC”.</p>
+
+<div class="revised">
+<p>A class is one or two letters, representing any character from the Unicode
+character category [<a href="#categories">Categories</a>] of that name, which
+<span id="ref-s10" class="conform">must</span> exist (<a class="error"
+href="#err-s10">error S10</a>). E.g. <code>[Ll]</code> matches any lower-case
+letter, <code>[Ll; Lu]</code> matches any upper- or lower-case character.</p>
+<pre class="frag">   -class: code.
+    @code: capital, letter?.
+ -capital: ["A"-"Z"].
+  -letter: ["A"-"Z" | "a"-"z"].</pre>
+</div>
+
+<h2 id="accepted">Accepted errata</h2>
+
+<p>None at this time.</p>
+
+</body>
+</html>

--- a/1.0/index.html
+++ b/1.0/index.html
@@ -24,6 +24,7 @@
       code {color: #A00}
       div {border: thin red solid}
       span.todo {background: yellow} 
+      .eip { background: #aaffaa; }
       img {float: right; width: 25%; margin-left: 1em; border: thin black solid}
       span.conform {font-weight: bold}
  </style>
@@ -34,7 +35,11 @@
 
 <p>Editor: Steven Pemberton, CWI, Amsterdam</p>
 
-<p>Version: <!--$date=-->2022-06-20<!--$--></p>
+<p>Version: <!--$date=-->2022-06-20<!--$--> <span class="eip">(edited in-place on 2022-09-29 to
+add a link to the errata page)</span></p>
+
+<p><span class="eip">Please consult the <a href="errata.html">errata page</a> for
+additional changes to the specification after publication.</span></p>
 
 <h2 id="status">Status</h2>
 


### PR DESCRIPTION
This pull request:

1. Adds an errata document to the web site (I put some draft text in it, but we can change that as we see fit)
2. Edits the iXML 1.0 specification "in place" to add a link to the errata page.

(Please note, this is a pull request against the `gh-pages` branch, *not* the `master` branch.)