### PR TITLE
Fix XML pages

### DIFF
--- a/build-tools/format-ixml.xsl
+++ b/build-tools/format-ixml.xsl
@@ -31,7 +31,7 @@
       It is also available <a href="ixml.xml.html">in XML</a>.</p>
       <div class="listing">
         <div id="toggle-buttons">
-          <a class="button" href="ixml.xml" download="ixml.xml">Download</a>
+          <a class="button" href="ixml.ixml" download="ixml.ixml">Download</a>
         </div>
         <pre id="ixml">
           <xsl:sequence select="f:highlight-ixml($text)"/>

--- a/build-tools/highlight-xml.xsl
+++ b/build-tools/highlight-xml.xsl
@@ -151,9 +151,9 @@
   <span class="attr">
     <span class="aname">{local-name(.)}</span>
     <span class="eq">=</span>
-    <span class="q">"</span>
-    <span class="avalue">{.}</span>
-    <span class="q">"</span>
+    <span class="q">'</span>
+    <span class="avalue">{replace(., "'", "&amp;apos;")}</span>
+    <span class="q">'</span>
   </span>
 </xsl:template>
 


### PR DESCRIPTION
1. Fix the handling of quotes in the interactive XML presentation.
2. Fix the download link on the interactive iXML presentation.
