### PR TITLE
Fix namespace and ambiguity errors

### DIFF
--- a/tests/chars/test-catalog.xml
+++ b/tests/chars/test-catalog.xml
@@ -58,7 +58,10 @@
       <test-string>Happy 😼</test-string>
       <result>
         <assert-xml>
-          <S><A>Happy</A><B>😸</B><C D="🙀">😾</C></S>
+          <S xmlns=""><A>Happy</A><B>😸</B><C D="🙀">😾</C></S>
+        </assert-xml>
+        <assert-xml>
+          <S xmlns=""><A>Happy</A><B>😼</B><C D="🙀">😾</C></S>
         </assert-xml>
       </result>
     </test-case>


### PR DESCRIPTION
I introduced an ambiguity into the parse but failed to account for that in the test results.

I also failed to account for the default namespace in the test results.
