### PR TITLE
Fix typo in ABNF grammar

### DIFF
--- a/samples/ABNF/ABNF.ixml
+++ b/samples/ABNF/ABNF.ixml
@@ -28,7 +28,7 @@ c-nl          = comment | CRLF.  { comment or newline }
 
 comment       = ";", (WSP | VCHAR)*, CRLF.
 
-alternation   = concatenation ** (c-wsp*, "/", c-wsp).
+alternation   = concatenation ** (c-wsp*, "/", c-wsp*).
 
 concatenation = repetition ** (c-wsp+).
 

--- a/samples/ABNF/ABNF.ixml
+++ b/samples/ABNF/ABNF.ixml
@@ -49,7 +49,7 @@ char-val      = DQUOTE, [#20 - #21; #23 - #7E]*, DQUOTE.
 
 num-val       = "%", (bin-val | dec-val | hex-val).
 
-bin-val       = "b", BIT+, ((".", bit+)+ | ("-", BIT+))?.
+bin-val       = "b", BIT+, ((".", BIT+)+ | ("-", BIT+))?.
                      { series of concatenated bit values
                        or single ONEOF range }
 


### PR DESCRIPTION
There's a typo in the sample grammar "bit" where "BIT" was required.