### PR TITLE
Add ABNF sample grammar that incorporates errata (and allows naked LF for newlines)

### DIFF
--- a/samples/ABNF-errata/ABNF.ixml
+++ b/samples/ABNF-errata/ABNF.ixml
@@ -6,7 +6,8 @@ have been reformulated to use ixml idioms.  The definition of ABNF has
 no analogue to ixml marks for guiding XML serialization; the marks
 used here have been supplied by the transcriber.
 
-Transcribed into ixml by C. M. Sperberg-McQueen, February 2022. }
+Transcribed into ixml by C. M. Sperberg-McQueen, February 2022.
+Updated by Norm Tovey-Walsh to incorporate errata, July 2023. }
 
 rulelist      = (rule | (c-wsp*, c-nl))+.
 
@@ -20,7 +21,7 @@ defined-as    = c-wsp*, ("=" | "=/"), c-wsp*.
                      {  basic rules definition and 
                         incremental alternatives }
 
-elements      = alternation, c-wsp*.
+elements      = alternation, WSP*.
 
 c-wsp         = WSP | (c-nl, WSP).
 

--- a/samples/ABNF-errata/ABNF.ixml
+++ b/samples/ABNF-errata/ABNF.ixml
@@ -72,7 +72,8 @@ BIT           = "0"; "1".
 
 CR            = #0D. { carriage return }
 
-CRLF          = CR, LF. { Internet standard newline }
+CRLF          = CR, LF { Internet standard newline }
+              | LF .   { Extension: support single LF convention for newlines }
 
 DIGIT         = ["0"-"9"]. { #30 - #39 }
 

--- a/samples/ABNF-errata/ABNF.ixml
+++ b/samples/ABNF-errata/ABNF.ixml
@@ -1,0 +1,127 @@
+{ The grammar notation defined by RFC 5234, "Augmented BNF for Syntax
+Specifications: ABNF", ed. D. Crocker and P. Overell, January 2008.
+
+The nonterminals used here are those of RFC 5234, but some definitions
+have been reformulated to use ixml idioms.  The definition of ABNF has
+no analogue to ixml marks for guiding XML serialization; the marks
+used here have been supplied by the transcriber.
+
+Transcribed into ixml by C. M. Sperberg-McQueen, February 2022. }
+
+rulelist      = (rule | (c-wsp*, c-nl))+.
+
+rule          = rulename, defined-as, elements, c-nl.
+                     { continues if next line starts 
+                       with white space }
+
+rulename      = ALPHA, (ALPHA | DIGIT | "-")*.
+
+defined-as    = c-wsp*, ("=" | "=/"), c-wsp*.
+                     {  basic rules definition and 
+                        incremental alternatives }
+
+elements      = alternation, c-wsp*.
+
+c-wsp         = WSP | (c-nl, WSP).
+
+c-nl          = comment | CRLF.  { comment or newline }
+
+comment       = ";", (WSP | VCHAR)*, CRLF.
+
+alternation   = concatenation ** (c-wsp*, "/", c-wsp).
+
+concatenation = repetition ** (c-wsp+).
+
+repetition    = repeat?, element.
+
+repeat        = DIGIT+ | (DIGIT*, "*", DIGIT*).
+
+element       = rulename | group | option 
+              | char-val | num-val | prose-val.
+
+group         = "(", c-wsp*, alternation, c-wsp*, ")".
+
+option        = "[", c-wsp*, alternation, c-wsp*, "]".
+
+char-val      = DQUOTE, [#20 - #21; #23 - #7E]*, DQUOTE.
+                     { quoted string of SP and VCHAR 
+                       without DQUOTE }
+
+num-val       = "%", (bin-val | dec-val | hex-val).
+
+bin-val       = "b", BIT+, ((".", BIT+)+ | ("-", BIT+))?.
+                     { series of concatenated bit values
+                       or single ONEOF range }
+
+dec-val       = "d", DIGIT+, ((".", DIGIT+)+ | ("-", DIGIT+))?.
+
+hex-val       = "x", HEXDIG+, ((".", HEXDIG+)+ | ("-", HEXDIG+))?.
+
+prose-val     = "<", [#20 - #3D; #3F - #7E]*, ">".
+                     { bracketed string of SP and VCHAR
+                       without angles
+                       prose description, to be used as
+                       last resort }
+
+{ 'Core rules' from Appendix B, intended for re-use. }
+
+ALPHA         = ["A"-"Z"; "a"-"z"]. { #41-#5A; #61-#7A }
+
+BIT           = "0"; "1".
+
+CR            = #0D. { carriage return }
+
+CRLF          = CR, LF. { Internet standard newline }
+
+DIGIT         = ["0"-"9"]. { #30 - #39 }
+
+DQUOTE        = #22. { (Double Quote) }
+
+HEXDIG        = DIGIT; ["A"-"F"].
+
+HTAB	      = #09. { horizontal tab }
+
+LF	      = #0A. { linefeed }
+
+SP            = #20.
+
+VCHAR         = [#21 - #7E]. { visible (printing) characters }
+
+WSP           = SP | HTAB. { white space }
+
+{ Included in Appendix B for reuse elsewhere, but not used
+by ABNF itself: }
+
+{
+
+CHAR          = [#01 - #7F].  
+                     { Any 7-bit US-ASCII chracter, 
+                       excluding NUL }
+		       
+CTL           = [#00 - #1F; #7F]. { controls }
+		       
+LWSP	      = (WSP | CRLF, WSP)*.
+                     { Use of this linear-white-space rule
+                       permits lines containing only white
+                       space that are no longer legal in
+                       mail headers and have caused 
+                       interoperability problems in other
+                       contexts.
+                       Do not use when defining mail
+                       headers and use with caution in 
+                       other contexts. }
+
+OCTET         = [#00 - #FF]. { 8 bits of data }
+
+}
+
+
+{ Notes:
+
+- As noted in the comments, this grammar has been reported ambiguous
+  in a couple of places.
+
+- ABNF nonterminals are case-insensitive unless specified using
+  numeric values for the characters.
+
+}

--- a/samples/ABNF-errata/ABNF.ixml
+++ b/samples/ABNF-errata/ABNF.ixml
@@ -9,7 +9,7 @@ used here have been supplied by the transcriber.
 Transcribed into ixml by C. M. Sperberg-McQueen, February 2022.
 Updated by Norm Tovey-Walsh to incorporate errata, July 2023. }
 
-rulelist      = (rule | (c-wsp*, c-nl))+.
+rulelist      = (rule | (WSP*, c-nl))+.
 
 rule          = rulename, defined-as, elements, c-nl.
                      { continues if next line starts 

--- a/samples/ABNF-errata/ABNF.ixml
+++ b/samples/ABNF-errata/ABNF.ixml
@@ -29,7 +29,7 @@ c-nl          = comment | CRLF.  { comment or newline }
 
 comment       = ";", (WSP | VCHAR)*, CRLF.
 
-alternation   = concatenation ** (c-wsp*, "/", c-wsp).
+alternation   = concatenation ** (c-wsp*, "/", c-wsp*).
 
 concatenation = repetition ** (c-wsp+).
 

--- a/samples/ABNF-errata/README.md
+++ b/samples/ABNF-errata/README.md
@@ -1,0 +1,8 @@
+# ABNF
+
+An ixml version of the grammar notation used in IETF Requests for
+Comment, as defined in [RFC 5234](https://www.rfc-editor.org/rfc/rfc5234.txt).
+
+## Change log
+
++ 2022-04-16, ndw, added README, corrected grammar to the 2022-04-15 editor’s draft.

--- a/samples/ABNF-errata/README.md
+++ b/samples/ABNF-errata/README.md
@@ -5,4 +5,8 @@ Comment, as defined in [RFC 5234](https://www.rfc-editor.org/rfc/rfc5234.txt).
 
 ## Change log
 
-+ 2022-04-16, ndw, added README, corrected grammar to the 2022-04-15 editor’s draft.
+* 2022-04-16, ndw, added README, corrected grammar to the 2022-04-15 editor’s draft.
+* 2023-07-31, ndw, applied the two errata verified at this time
+  [2968](https://www.rfc-editor.org/errata/eid2968) and
+  [3076](https://www.rfc-editor.org/errata/eid3076).
+  Also allow `LF` as an alternative to `CR, LF` on purely practical grounds.

--- a/samples/ABNF/ABNF.ixml
+++ b/samples/ABNF/ABNF.ixml
@@ -28,7 +28,7 @@ c-nl          = comment | CRLF.  { comment or newline }
 
 comment       = ";", (WSP | VCHAR)*, CRLF.
 
-alternation   = concatenation ** (c-wsp*, "/", c-wsp).
+alternation   = concatenation ** (c-wsp*, "/", c-wsp*).
 
 concatenation = repetition ** (c-wsp+).
 

--- a/samples/ABNF/ABNF.ixml
+++ b/samples/ABNF/ABNF.ixml
@@ -49,7 +49,7 @@ char-val      = DQUOTE, [#20 - #21; #23 - #7E]*, DQUOTE.
 
 num-val       = "%", (bin-val | dec-val | hex-val).
 
-bin-val       = "b", BIT+, ((".", bit+)+ | ("-", BIT+))?.
+bin-val       = "b", BIT+, ((".", BIT+)+ | ("-", BIT+))?.
                      { series of concatenated bit values
                        or single ONEOF range }
 


### PR DESCRIPTION
This PR adds a new sample grammar, ABNF with the two verified errata applied. It also extends the grammar to support a single `LF` as a newline for purely pragmatic reasons.

The two errata applied to RFC 5234 were applied to resolve ambiguities. Curiously, Möller's [ambiguity analyzer](https://www.brics.dk/grammar/) says there are more. But I haven't investigated any of them.

```
The grammar is ambiguous:
*** vertical ambiguity: $30_$1_alt-plus[#1] <--> $30_$1_alt-plus[#2]
    ambiguous string: "A=\n\t\n"
*** potential vertical ambiguity: $59_$27_c-wsp-star-plus[#1] <--> $59_$27_c-wsp-star-plus[#2]
*** potential vertical ambiguity: $61_$60_c-wsp-plus-plus[#1] <--> $61_$60_c-wsp-plus-plus[#2]
*** vertical ambiguity: $9_concatenation-star-sep[#1] <--> $9_concatenation-star-sep[#2]
    ambiguous string: ""
*** horizontal ambiguity: rule[#1]: rulename defined-as <--> elements c-nl
    ambiguous string: "A=\t\n"
    matched as "A=" <--> "\t\n" or "A=\t" <--> "\n"
*** potential horizontal ambiguity: elements[#1]: alternation <--> $16_WSP-star
*** horizontal ambiguity: group[#1]: "(" $20_c-wsp-star <--> alternation $21_c-wsp-star ")"
    ambiguous string: "(\t)"
    matched as "(" <--> "\t)" or "(\t" <--> ")"
*** horizontal ambiguity: group[#1]: "(" $20_c-wsp-star alternation <--> $21_c-wsp-star ")"
    ambiguous string: "(\t)"
    matched as "(" <--> "\t)" or "(\t" <--> ")"
*** horizontal ambiguity: option[#1]: "[" $22_c-wsp-star <--> alternation $23_c-wsp-star "]"
    ambiguous string: "[\t]"
    matched as "[" <--> "\t]" or "[\t" <--> "]"
*** horizontal ambiguity: option[#1]: "[" $22_c-wsp-star alternation <--> $23_c-wsp-star "]"
    ambiguous string: "[\t]"
    matched as "[" <--> "\t]" or "[\t" <--> "]"
*** potential horizontal ambiguity: $11_concatenation-plus-sep[#1]: concatenation <--> $28_$27_c-wsp-star-star
*** potential horizontal ambiguity: $12_repetition-plus-sep[#1]: repetition <--> $29_star
*** horizontal ambiguity: $30_$1_alt-plus[#2]: $1_alt <--> $30_$1_alt-plus
    ambiguous string: "A=\n\t\n\n"
    matched as "A=\n" <--> "\t\n\n" or "A=\n\t\n" <--> "\n"
*** potential horizontal ambiguity: $59_$27_c-wsp-star-plus[#2]: $27_c-wsp-star "/" c-wsp concatenation <--> $59_$27_c-wsp-star-plus
*** potential horizontal ambiguity: $61_$60_c-wsp-plus-plus[#2]: $60_c-wsp-plus repetition <--> $61_$60_c-wsp-plus-plus
```

For reference, here is the BNF grammar analyzed (this is the ixml grammar transformed into BNF by [CoffeeGrinder](https://coffeegrinder.nineml.org/) ):

```
The Earley grammar (176 rules):
  1.                         $$ ::= rulelist
  2.                   rulelist ::= $30_$1_alt-plus
  3.                       rule ::= rulename, defined-as, elements, c-nl
  4.                   rulename ::= ALPHA, $13_$2_alt-starⁿ
  5.                 defined-as ::= $14_c-wsp-starⁿ, $3_alt, $15_c-wsp-starⁿ
  6.                   elements ::= alternation, $16_WSP-starⁿ
  7.                      c-wsp ::= WSP
  8.                      c-wsp ::= c-nl, WSP
  9.                       c-nl ::= comment
 10.                       c-nl ::= CRLF
 11.                    comment ::= ';', $17_$4_alt-starⁿ, CRLF
 12.                alternation ::= $9_concatenation-star-sepⁿ
 13.              concatenation ::= $10_repetition-star-sepⁿ
 14.                 repetition ::= $62_repeat-optionⁿ, element
 15.                     repeat ::= $31_DIGIT-plus
 16.                     repeat ::= $18_DIGIT-starⁿ, '*', $19_DIGIT-starⁿ
 17.                    element ::= rulename
 18.                    element ::= group
 19.                    element ::= option
 20.                    element ::= char-val
 21.                    element ::= num-val
 22.                    element ::= prose-val
 23.                      group ::= '(', $20_c-wsp-starⁿ, alternation, $21_c-wsp-starⁿ, ')'
 24.                     option ::= '[', $22_c-wsp-starⁿ, alternation, $23_c-wsp-starⁿ, ']'
 25.                   char-val ::= DQUOTE, $24_starⁿ, DQUOTE
 26.                    num-val ::= '%', $5_alt
 27.                    bin-val ::= 'b', $32_BIT-plus, $63_$6_alt-optionⁿ
 28.                    dec-val ::= 'd', $33_DIGIT-plus, $64_$7_alt-optionⁿ
 29.                    hex-val ::= 'x', $34_HEXDIG-plus, $65_$8_alt-optionⁿ
 30.                  prose-val ::= '<', $25_starⁿ, '>'
 31.                      ALPHA ::= ['A'-'Z'; 'a'-'z']
 32.                        BIT ::= '0'
 33.                        BIT ::= '1'
 34.                         CR ::= #D
 35.                       CRLF ::= CR, LF
 36.                       CRLF ::= LF
 37.                      DIGIT ::= ['0'-'9']
 38.                     DQUOTE ::= '"'
 39.                     HEXDIG ::= DIGIT
 40.                     HEXDIG ::= ['A'-'F']
 41.                       HTAB ::= #9
 42.                         LF ::= #A
 43.                         SP ::= ' '
 44.                      VCHAR ::= ['!'-'~']
 45.                        WSP ::= SP
 46.                        WSP ::= HTAB
 47.                     $1_alt ::= rule
 48.                     $1_alt ::= $26_WSP-starⁿ, c-nl
 49.                     $2_alt ::= ALPHA
 50.                     $2_alt ::= DIGIT
 51.                     $2_alt ::= '-'
 52.                     $3_alt ::= '='
 53.                     $3_alt ::= '=', '/'
 54.                     $4_alt ::= WSP
 55.                     $4_alt ::= VCHAR
 56.                     $5_alt ::= bin-val
 57.                     $5_alt ::= dec-val
 58.                     $5_alt ::= hex-val
 59.                     $6_alt ::= $36_L.-plus
 60.                     $6_alt ::= '-', $37_BIT-plus
 61.                     $7_alt ::= $39_L.-plus
 62.                     $7_alt ::= '-', $40_DIGIT-plus
 63.                     $8_alt ::= $42_L.-plus
 64.                     $8_alt ::= '-', $43_HEXDIG-plus
 65. $9_concatenation-star-sepⁿ ::= ε
 66. $9_concatenation-star-sepⁿ ::= $11_concatenation-plus-sep
 67.   $10_repetition-star-sepⁿ ::= ε
 68.   $10_repetition-star-sepⁿ ::= $12_repetition-plus-sep
 69. $11_concatenation-plus-sep ::= concatenation, $28_$27_c-wsp-star-starⁿ
 70.    $12_repetition-plus-sep ::= repetition, $29_starⁿ
 71.           $13_$2_alt-starⁿ ::= ε
 72.           $13_$2_alt-starⁿ ::= $44_$2_alt-plus
 73.            $14_c-wsp-starⁿ ::= ε
 74.            $14_c-wsp-starⁿ ::= $45_c-wsp-plus
 75.            $15_c-wsp-starⁿ ::= ε
 76.            $15_c-wsp-starⁿ ::= $46_c-wsp-plus
 77.              $16_WSP-starⁿ ::= ε
 78.              $16_WSP-starⁿ ::= $47_WSP-plus
 79.           $17_$4_alt-starⁿ ::= ε
 80.           $17_$4_alt-starⁿ ::= $48_$4_alt-plus
 81.            $18_DIGIT-starⁿ ::= ε
 82.            $18_DIGIT-starⁿ ::= $49_DIGIT-plus
 83.            $19_DIGIT-starⁿ ::= ε
 84.            $19_DIGIT-starⁿ ::= $50_DIGIT-plus
 85.            $20_c-wsp-starⁿ ::= ε
 86.            $20_c-wsp-starⁿ ::= $51_c-wsp-plus
 87.            $21_c-wsp-starⁿ ::= ε
 88.            $21_c-wsp-starⁿ ::= $52_c-wsp-plus
 89.            $22_c-wsp-starⁿ ::= ε
 90.            $22_c-wsp-starⁿ ::= $53_c-wsp-plus
 91.            $23_c-wsp-starⁿ ::= ε
 92.            $23_c-wsp-starⁿ ::= $54_c-wsp-plus
 93.                  $24_starⁿ ::= ε
 94.                  $24_starⁿ ::= $55_plus
 95.                  $25_starⁿ ::= ε
 96.                  $25_starⁿ ::= $56_plus
 97.              $26_WSP-starⁿ ::= ε
 98.              $26_WSP-starⁿ ::= $57_WSP-plus
 99.            $27_c-wsp-starⁿ ::= ε
100.            $27_c-wsp-starⁿ ::= $58_c-wsp-plus
101.   $28_$27_c-wsp-star-starⁿ ::= ε
102.   $28_$27_c-wsp-star-starⁿ ::= $59_$27_c-wsp-star-plus
103.                  $29_starⁿ ::= ε
104.                  $29_starⁿ ::= $61_$60_c-wsp-plus-plus
105.            $30_$1_alt-plus ::= $1_alt
106.            $30_$1_alt-plus ::= $1_alt, $30_$1_alt-plus
107.             $31_DIGIT-plus ::= DIGIT
108.             $31_DIGIT-plus ::= DIGIT, $31_DIGIT-plus
109.               $32_BIT-plus ::= BIT
110.               $32_BIT-plus ::= BIT, $32_BIT-plus
111.             $33_DIGIT-plus ::= DIGIT
112.             $33_DIGIT-plus ::= DIGIT, $33_DIGIT-plus
113.            $34_HEXDIG-plus ::= HEXDIG
114.            $34_HEXDIG-plus ::= HEXDIG, $34_HEXDIG-plus
115.               $35_BIT-plus ::= BIT
116.               $35_BIT-plus ::= BIT, $35_BIT-plus
117.                $36_L.-plus ::= '.', $35_BIT-plus
118.                $36_L.-plus ::= '.', $35_BIT-plus, $36_L.-plus
119.               $37_BIT-plus ::= BIT
120.               $37_BIT-plus ::= BIT, $37_BIT-plus
121.             $38_DIGIT-plus ::= DIGIT
122.             $38_DIGIT-plus ::= DIGIT, $38_DIGIT-plus
123.                $39_L.-plus ::= '.', $38_DIGIT-plus
124.                $39_L.-plus ::= '.', $38_DIGIT-plus, $39_L.-plus
125.             $40_DIGIT-plus ::= DIGIT
126.             $40_DIGIT-plus ::= DIGIT, $40_DIGIT-plus
127.            $41_HEXDIG-plus ::= HEXDIG
128.            $41_HEXDIG-plus ::= HEXDIG, $41_HEXDIG-plus
129.                $42_L.-plus ::= '.', $41_HEXDIG-plus
130.                $42_L.-plus ::= '.', $41_HEXDIG-plus, $42_L.-plus
131.            $43_HEXDIG-plus ::= HEXDIG
132.            $43_HEXDIG-plus ::= HEXDIG, $43_HEXDIG-plus
133.            $44_$2_alt-plus ::= $2_alt
134.            $44_$2_alt-plus ::= $2_alt, $44_$2_alt-plus
135.             $45_c-wsp-plus ::= c-wsp
136.             $45_c-wsp-plus ::= c-wsp, $45_c-wsp-plus
137.             $46_c-wsp-plus ::= c-wsp
138.             $46_c-wsp-plus ::= c-wsp, $46_c-wsp-plus
139.               $47_WSP-plus ::= WSP
140.               $47_WSP-plus ::= WSP, $47_WSP-plus
141.            $48_$4_alt-plus ::= $4_alt
142.            $48_$4_alt-plus ::= $4_alt, $48_$4_alt-plus
143.             $49_DIGIT-plus ::= DIGIT
144.             $49_DIGIT-plus ::= DIGIT, $49_DIGIT-plus
145.             $50_DIGIT-plus ::= DIGIT
146.             $50_DIGIT-plus ::= DIGIT, $50_DIGIT-plus
147.             $51_c-wsp-plus ::= c-wsp
148.             $51_c-wsp-plus ::= c-wsp, $51_c-wsp-plus
149.             $52_c-wsp-plus ::= c-wsp
150.             $52_c-wsp-plus ::= c-wsp, $52_c-wsp-plus
151.             $53_c-wsp-plus ::= c-wsp
152.             $53_c-wsp-plus ::= c-wsp, $53_c-wsp-plus
153.             $54_c-wsp-plus ::= c-wsp
154.             $54_c-wsp-plus ::= c-wsp, $54_c-wsp-plus
155.                   $55_plus ::= [' '-'!'; '#'-'~']
156.                   $55_plus ::= [' '-'!'; '#'-'~'], $55_plus
157.                   $56_plus ::= [' '-'='; '?'-'~']
158.                   $56_plus ::= [' '-'='; '?'-'~'], $56_plus
159.               $57_WSP-plus ::= WSP
160.               $57_WSP-plus ::= WSP, $57_WSP-plus
161.             $58_c-wsp-plus ::= c-wsp
162.             $58_c-wsp-plus ::= c-wsp, $58_c-wsp-plus
163.    $59_$27_c-wsp-star-plus ::= $27_c-wsp-starⁿ, '/', c-wsp, concatenation
164.    $59_$27_c-wsp-star-plus ::= $27_c-wsp-starⁿ, '/', c-wsp, concatenation, $59_$27_c-wsp-star-plus
165.             $60_c-wsp-plus ::= c-wsp
166.             $60_c-wsp-plus ::= c-wsp, $60_c-wsp-plus
167.    $61_$60_c-wsp-plus-plus ::= $60_c-wsp-plus, repetition
168.    $61_$60_c-wsp-plus-plus ::= $60_c-wsp-plus, repetition, $61_$60_c-wsp-plus-plus
169.         $62_repeat-optionⁿ ::= ε
170.         $62_repeat-optionⁿ ::= repeat
171.         $63_$6_alt-optionⁿ ::= ε
172.         $63_$6_alt-optionⁿ ::= $6_alt
173.         $64_$7_alt-optionⁿ ::= ε
174.         $64_$7_alt-optionⁿ ::= $7_alt
175.         $65_$8_alt-optionⁿ ::= ε
176.         $65_$8_alt-optionⁿ ::= $8_alt
```
