### PR TITLE
Fix broken markup in test-catalog

### DIFF
--- a/tests/correct/test-catalog.xml
+++ b/tests/correct/test-catalog.xml
@@ -1,4 +1,4 @@
-<test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog
+<test-catalog xmlns="https://github.com/invisibleXML/ixml/test-catalog"
               release-date="2022-11-22"
 	      name="Tests producing parse trees">
 
@@ -1280,6 +1280,9 @@
       <test-string>&#x9;c </test-string>
       <result>
 	<assert-not-a-sentence/>
+      </result>
+    </test-case>
+  </test-set>
         
   <test-set name="naming-elements">
     <description>


### PR DESCRIPTION
I'm not sure how this commit got past the build process. There are markup errors in the test catalog. I'm just going to push this fix.