### PR TITLE
Adapt test case correct/version-decl.2.ixml to recent changes of prolog

### DIFF
--- a/tests/correct/version-decl.2.ixml
+++ b/tests/correct/version-decl.2.ixml
@@ -3,4 +3,4 @@
 
 
 
-ixml{}version{}"experimental induction of parser failure under stress".S=;'done'.
+ixml{}version{}"experimental induction of parser failure under stress". S=;'done'.


### PR DESCRIPTION
The first rule in the grammar of test case `correct/version-decl.2.ixml` is immediately preceded by the end of the prolog, without any intervening whitespace. This is no longer permitted after the recent merge of #222, fixing #199.

This change adds a single space to adapt the test case to the new requirement.