### PR TITLE
Add publication metadata to ixml grammar files

### DIFF
--- a/build-tools/extract-ixml.xsl
+++ b/build-tools/extract-ixml.xsl
@@ -5,12 +5,50 @@
                 exclude-result-prefixes="#all"
                 version="3.0">
 
+<xsl:param name="ci-sha1" select="''" as="xs:string"/>
+<xsl:param name="ci-build-num" select="''" as="xs:string"/>
+<xsl:param name="ci-project-username" select="''" as="xs:string"/>
+<xsl:param name="ci-project-reponame" select="''" as="xs:string"/>
+<xsl:param name="ci-branch" select="''" as="xs:string"/>
+<xsl:param name="ci-tag" select="''" as="xs:string"/>
+<xsl:param name="ci-pull" select="''" as="xs:string"/>
+
 <xsl:output method="text" encoding="utf-8" indent="no"/>
 
 <xsl:variable name="spaces" select="'              '"/>
 
 <xsl:template match="h:body">
-  <xsl:apply-templates select="h:p[starts-with(., 'Version:')]"/>
+  <!-- Ok, now we have to make some heuristic choices ... -->
+  <xsl:variable name="uri" as="xs:string" expand-text="yes">
+    <xsl:choose>
+      <xsl:when test="$ci-project-username = 'invisibleXML'
+                      and $ci-pull = 'null'">
+        <xsl:text>https://invisiblexml.org/current/</xsl:text>
+      </xsl:when>
+      <xsl:when test="$ci-project-username = 'invisibleXML'">
+        <xsl:text>https://invisiblexml.org/pr/{$ci-pull}/</xsl:text>
+      </xsl:when>
+      <xsl:when test="$ci-project-username = ''">
+        <xsl:sequence select="resolve-uri('../build/current/index.html', static-base-uri())"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>https://{$ci-project-username}.github.io/{$ci-project-reponame}/branch/{$ci-branch}/</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:text>{ Invisible XML specification grammar, </xsl:text>
+  <xsl:sequence select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
+  <xsl:text> }&#10;</xsl:text>
+  <xsl:text>{ Published in </xsl:text>
+  <xsl:sequence select="$uri"/>
+  <xsl:text> }&#10;</xsl:text>
+  <xsl:if test="$ci-sha1 != ''">
+    <xsl:text>{ Commit hash </xsl:text>
+    <xsl:sequence select="substring($ci-sha1, 1, 12)"/>
+    <xsl:text> }&#10;</xsl:text>
+  </xsl:if>
+  <xsl:text>&#10;</xsl:text>
 
   <xsl:variable name="chunks" as="document-node()+">
     <xsl:for-each select="h:pre[contains-token(@class, 'frag')]">
@@ -33,12 +71,6 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
-</xsl:template>
-
-<xsl:template match="h:p[starts-with(., 'Version:')]">
-  <xsl:text>{version </xsl:text>
-  <xsl:sequence select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
-  <xsl:text>}&#10;</xsl:text>
 </xsl:template>
 
 <xsl:template match="h:pre[contains-token(@class, 'frag')]">


### PR DESCRIPTION
Close #253 

This PR adds publication metadata to the top of the ixml grammar files, like so:

```
{ Invisible XML specification grammar, 2024-06-12 }
{ Published in https://ndw.github.io/ixml/branch/iss-253/ }
{ Commit hash e70cc5e29367 }
```

