### PR TITLE
Added XMQ to the list of implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,6 @@ writing grammars</a> on <a href="https://www.xml.com/">xml.com</a>.</li>
 <h2>Implementations</h2>
 
 <ul>
-<li><a href="https://www.agencexml.com/ixml/tester.xml">Invisible XML</a> support is
-being added to XsltForms by Alain Couthures.</li>
 <li><a href="https://github.com/cmsmcq/Aparecium">Aparecium</a> is
 Michael Sperberg-McQueen’s proof-of-concept implementation in
 XQuery.</li>
@@ -88,19 +86,24 @@ XQuery.</li>
 Tovey-Walsh’s Java implementation.</li>
 <li><a href="https://github.com/mdubinko/earleybird">EarleyBird</a> is M. Joel Dubinko’s
 Rust implementation (in development)</li>
+<li>Hywel is Bethan Tovey-Walsh’s Python implementation (in development)</li>
 <li><a href="https://www.cwi.nl/~steven/ixml/tutorial/run.html">ixampl</a>
 is Steven Pemberton’s implementation (it is available online as a web
 service).</li>
-<li><a href="https://github.com/johnlumley/jwiXML">jωiXML</a> is
-John Lumley’s browser-based
-<a href="https://johnlumley.github.io/jwiXML.xhtml">JavaScript implementation</a>.</li>
 <li><a href="https://github.com/eXpertML/JayParser">JayParser</a>
 is Tomos Hillman’s XSLT implementation
 (in progress).</li>
-<li>Hywel is Bethan Tovey-Walsh’s Python implementation (in development)</li>
+<li><a href="https://github.com/johnlumley/jwiXML">jωiXML</a> is
+John Lumley’s browser-based
+<a href="https://johnlumley.github.io/jwiXML.xhtml">JavaScript implementation</a>.</li>
 <li><a href="https://github.com/GuntherRademacher/markup-blitz">Markup Blitz</a>
 is Gunther Rademacher’s Java implementation.
 </li>
+<li>Fredrik Öhrström has added Invisible XML support to
+<a href="https://github.com/libxmq/xmq">XMQ</a>.</li>
+<li>Alain Couthures is adding
+<a href="https://www.agencexml.com/ixml/tester.xml">Invisible XML</a> support
+to XsltForms.</li>
 </ul>
 
 </div>


### PR DESCRIPTION
Close #285 

I also sorted them into alphabetical order by implementation name. Not sure that's best, but it's less...random.